### PR TITLE
Add back to dashboard link

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -28,6 +28,7 @@
       <button class="tab" data-tab="students" type="button" aria-controls="students" aria-selected="false">Students</button>
       <button class="tab" data-tab="courses" type="button" aria-controls="courses" aria-selected="false">Courses</button>
       <button class="tab" data-tab="logs" type="button" aria-controls="logs" aria-selected="false">Logs</button>
+      <a class="tab" href="/" aria-label="Back to main dashboard">Back to Dashboard</a>
     </nav>
   </header>
 

--- a/admin/style.css
+++ b/admin/style.css
@@ -17,8 +17,8 @@ header h1{font-size:1.4rem;margin:0;font-weight:600}
 /* Navigation */
 nav{display:flex;gap:.5rem;flex-wrap:wrap}
 .nav-menu{display:flex;gap:.5rem;flex-wrap:wrap}
-button.tab{padding:.5rem .8rem;border-radius:999px;border:1px solid var(--border);background:#0a1123;color:inherit;text-decoration:none;transition:all 0.2s ease;cursor:pointer;font-size:14px;font-weight:500}
-button.tab:hover{background:rgba(34,197,94,0.1);border-color:var(--accent)}
+button.tab,.nav-menu a.tab{padding:.5rem .8rem;border-radius:999px;border:1px solid var(--border);background:#0a1123;color:inherit;text-decoration:none;transition:all 0.2s ease;cursor:pointer;font-size:14px;font-weight:500;display:inline-block}
+button.tab:hover,.nav-menu a.tab:hover{background:rgba(34,197,94,0.1);border-color:var(--accent)}
 button.tab.active{background:linear-gradient(135deg,#1e293b,#0b1226)}
 
 /* Cards */
@@ -81,7 +81,7 @@ pre{background:#0a1123;border:1px solid var(--border);border-radius:10px;padding
   .hamburger{display:flex}
   .nav-menu{position:absolute;top:100%;left:0;right:0;background:rgba(15,23,42,.95);backdrop-filter:blur(10px);border-bottom:1px solid var(--border);flex-direction:column;padding:1rem;transform:translateY(-100%);opacity:0;visibility:hidden;transition:all 0.3s ease}
   .nav-menu.active{transform:translateY(0);opacity:1;visibility:visible}
-  .nav-menu button.tab{width:100%;border-radius:8px;margin-bottom:0.5rem;text-align:left}
+  .nav-menu button.tab,.nav-menu a.tab{width:100%;border-radius:8px;margin-bottom:0.5rem;text-align:left}
   .wrap{padding:16px}
   .card{padding:16px}
   form.inline{grid-template-columns:1fr}


### PR DESCRIPTION
Add "Back to Dashboard" link to admin console navigation.

This provides a direct menu action for users to return to the main dashboard from the admin console, improving navigation flow. The new link is styled to match existing navigation tabs.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d0cd3de-73ca-4e4c-a283-cbffd5910a1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d0cd3de-73ca-4e4c-a283-cbffd5910a1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

