### PR TITLE
Fix admin page course adding bug

### DIFF
--- a/netlify/functions/api.mjs
+++ b/netlify/functions/api.mjs
@@ -1,6 +1,4 @@
 import { neon } from '@neondatabase/serverless';
-import { drizzle } from 'drizzle-orm/neon-http';
-import { eq, sql, desc } from 'drizzle-orm';
 
 // Import schema manually since ES modules don't support relative imports in Netlify functions
 const schema = {
@@ -74,7 +72,6 @@ export async function handler(event) {
     }
 
     const sql = neon(process.env.NETLIFY_DATABASE_URL);
-    const db = drizzle(sql, { schema });
     const path = event.path || '';
 
     // Health check endpoint


### PR DESCRIPTION
Fixes "Add courses" failure by resolving a duplicate `sql` identifier in `netlify/functions/api.mjs`.

The API function used to reload the courses list after adding had a naming conflict that crashed the function module, making “Add Course” appear to fail. The file `netlify/functions/api.mjs` imported a symbol named `sql` and then redeclared `const sql = neon(...)`, which threw “Identifier 'sql' has already been declared”. This change removes the conflicting import and unused Drizzle setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b402d6a-e1bc-4f2a-9d7c-02a52391bf42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b402d6a-e1bc-4f2a-9d7c-02a52391bf42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

